### PR TITLE
Expand pynvml wrapper

### DIFF
--- a/pynvx/pynvml.py
+++ b/pynvx/pynvml.py
@@ -49,6 +49,10 @@ def _cudaDeviceGetMemoryInfo(handle):
     info = pynvx.cudaGetMemInfo(handle)
     return GPUMemory(*info)
 
+def _cudaSystemGetDriverVersion():
+    version = pynvx.cudaSystemGetDriverVersion()
+    return str(version)
+
 
 def _not_implemented_func(*args, **kwargs):
     raise RuntimeError('Not implemented by pynvx, contribution is welcomed: '
@@ -83,7 +87,9 @@ if _is_osx:
         'nvmlDeviceGetHandleByIndex': _cudaDeviceGetHandleByIndex,
         'nvmlDeviceGetIndex': _cudaDeviceGetIndex,
         'nvmlDeviceGetMemoryInfo': _cudaDeviceGetMemoryInfo,
-        'nvmlDeviceGetName': getattr(pynvx, 'cudaGetName')
+        'nvmlDeviceGetName': getattr(pynvx, 'cudaGetName'),
+        'nvmlSystemGetDriverVersion': _cudaSystemGetDriverVersion,
+        'nvmlSystemGetRuntimeVersion': getattr(pynvx, 'cudaSystemGetRuntimeVersion')
     }
 
     for func_name, _ in inspect.getmembers(pynvml, inspect.isroutine):


### PR DESCRIPTION
I added `nvmlSystemGetDriverVersion` and `nvmlSystemGetRuntimeVersion` to the pynvml wrapper.
While testing, I wondered about the driver version reporter through `cudaSystemGetDriverVersion()`.
I got a return value of `10000`. Is this a valid driver version?